### PR TITLE
fix: support master

### DIFF
--- a/Sources/DangerSwiftEda/GitFlow.swift
+++ b/Sources/DangerSwiftEda/GitFlow.swift
@@ -354,7 +354,7 @@ extension GitFlow.Branch {
     public static func defaultParsingMethod(name: String) -> Self? {
         
         switch name {
-        case "main":
+        case "main", "master":
             return .main
             
         case "develop":

--- a/Sources/DangerSwiftEda/GitHubFlow.swift
+++ b/Sources/DangerSwiftEda/GitHubFlow.swift
@@ -228,7 +228,7 @@ extension GitHubFlow.Branch {
     public static func defaultParsingMethod(name: String) -> Self? {
         
         switch name {
-        case "main":
+        case "main", "master":
             return .main
             
         case "ci":


### PR DESCRIPTION
# what

- support master branch

## etc

branchParsingMethodを使用者側で拡張してもいいんだけどね

`swift run danger-swift ci` だとassertionFailureで落ちてしまうので`-c release`で動かせばコメントはちゃんと動く
https://github.com/yumemi-inc/danger-swift-eda/blob/038ed1081661ac4c9e87382aa9b8589b5bdc1a20/Sources/DangerSwiftEda/GitFlow.swift#L109